### PR TITLE
Potential fix for code scanning alert no. 4: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/AutoRelease.yml
+++ b/.github/workflows/AutoRelease.yml
@@ -221,7 +221,7 @@ jobs:
 
     steps:
     - run: mkdir -p ./builds
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@4.1.7
       with:
         path: ./builds
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sgn/security/code-scanning/4](https://github.com/offsoc/sgn/security/code-scanning/4)

To fix the problem, we need to update the version of the `actions/download-artifact` action from `v3` to `4.1.7`. This change will ensure that the workflow uses a version of the action that does not have known vulnerabilities. The update should be made in the `.github/workflows/AutoRelease.yml` file, specifically on line 224 where the action is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
